### PR TITLE
Tabs instead of spaces

### DIFF
--- a/ext/dream_cheeky/extconf.rb
+++ b/ext/dream_cheeky/extconf.rb
@@ -49,7 +49,7 @@ if RUBY_VERSION < "1.9.3"
   open("Makefile", "a") do |f|
     f.puts <<-EOS
 .m.o:
-  $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG)$@ -c $<
-    EOS
+	$(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) $@ -c $<
+	EOS
   end
 end


### PR DESCRIPTION
Use tabs instead of spaces when constructing the makefile to create a valid separator.
Using spaces breaks the make step as spaces are not valid command separators.

Will need to be careful around this code in the future to prevent IDEs from automatically assuming we want spaces here.