### PR TITLE
Update cflags

### DIFF
--- a/ext/dream_cheeky/extconf.rb
+++ b/ext/dream_cheeky/extconf.rb
@@ -4,8 +4,6 @@ require 'fileutils'
 
 if RbConfig::CONFIG['host_os'] =~ /darwin/
 
-  $CFLAGS << " " << "-ObjC"
-
   unless defined?(have_framework)
     def have_framework(fw, &b)
       checking_for fw do


### PR DESCRIPTION
The `-ObjC` flag was breaking my install on Mac OS 10.8.5; removing it fixed everything, and the gem works wonderfully. Wondering whether this flag might be deprecated and should be removed.
